### PR TITLE
Makefile changes for kubefedctl client

### DIFF
--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -108,16 +108,9 @@ OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} make -f openshift/Mak
 %endif
 
 %install
-
-PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 install -d %{buildroot}%{_bindir}
 
-# Install linux components
-for bin in 'kubefedctl'
-do
-    echo "+++ INSTALLING ${bin}"
-    install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
-done
+install -p -m 755 $RPM_BUILD_DIR/go/bin/kubefedctl* %{buildroot}%{_bindir}/kubefedctl
 
 # EXAMPLE: Install tests
 # install -d %{buildroot}%{_libexecdir}/%{name}

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -46,7 +46,7 @@
 
 %global package_name kubefed-client
 %global product_name Kubefed Client
-%global import_path github\.com\/openshift\/kubefed # GO_PACKAGE
+%global import_path github.com/openshift/kubefed # GO_PACKAGE
 
 Name:           %{package_name}
 Version:        %{version}
@@ -71,11 +71,18 @@ ExclusiveArch:  x86_64 aarch64 ppc64le s390x
 This package provides the kubefed-client binary (kubefedctl) to interact with the kubefed controller
 
 %prep
-%if 0%{do_prep}
+GOPATH=$RPM_BUILD_DIR/go
+rm -rf $GOPATH
+mkdir -p $GOPATH/src/%{import_path}
 %setup -q
-%endif
+DIR=$RPM_BUILD_DIR/kubefed-client*
+mv $DIR/*  $GOPATH/src/github.com/openshift/kubefed/
+ln -s $GOPATH/src/github.com/openshift/kubefed $DIR
 
 %build
+export GOPATH=$RPM_BUILD_DIR/go
+cd $GOPATH/src/github.com/openshift/kubefed
+ln -s $GOPATH/sigs.k8s.io/kubefed $GOPATH/src/%{import_path}
 %if 0%{do_build}
 %if 0%{make_redistributable}
 # Create Binaries for all internally defined arches

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -46,7 +46,7 @@
 
 %global package_name kubefed-client
 %global product_name Kubefed Client
-%global import_path github\.com\/openshift\/kubefed # GO_PACKAGE
+%global import_path github.com/openshift/kubefed # GO_PACKAGE
 
 Name:           %{package_name}
 Version:        %{version}

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -73,16 +73,15 @@ This package provides the kubefed-client binary (kubefedctl) to interact with th
 %prep
 GOPATH=$RPM_BUILD_DIR/go
 rm -rf $GOPATH
-mkdir -p $GOPATH/src/%{import_path}
+mkdir -p $GOPATH/src/sigs.k8s.io/kubefed
 %setup -q
 DIR=$RPM_BUILD_DIR/kubefed-client*
-mv $DIR/*  $GOPATH/src/github.com/openshift/kubefed/
-ln -s $GOPATH/src/github.com/openshift/kubefed $DIR
+mv $DIR/*  $GOPATH/src/sigs.k8s.io/kubefed/
+ln -s $GOPATH/src/sigs.k8s.io/kubefed/kubefed $DIR
 
 %build
 export GOPATH=$RPM_BUILD_DIR/go
-cd $GOPATH/src/github.com/openshift/kubefed
-ln -s $GOPATH/sigs.k8s.io/kubefed $GOPATH/src/%{import_path}
+cd $GOPATH/src/sigs.k8s.io/kubefed
 %if 0%{do_build}
 %if 0%{make_redistributable}
 # Create Binaries for all internally defined arches

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -74,7 +74,10 @@ This package provides the kubefed-client binary (kubefedctl) to interact with th
 GOPATH=$RPM_BUILD_DIR/go
 rm -rf $GOPATH
 mkdir -p $GOPATH/src/sigs.k8s.io/kubefed
-%setup -q
+cd $RPM_BUILD_DIR
+rm -rf kubefed-client*
+tar -xzmf %{_sourcedir}/kubefed-client*
+cd kubefed-client*
 DIR=$RPM_BUILD_DIR/kubefed-client*
 mv $DIR/*  $GOPATH/src/sigs.k8s.io/kubefed/
 ln -s $GOPATH/src/sigs.k8s.io/kubefed/kubefed $DIR

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -113,7 +113,7 @@ OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} make -f openshift/Mak
 %install
 install -d %{buildroot}%{_bindir}
 
-install -p -m 755 $RPM_BUILD_DIR/go/bin/kubefedctl* %{buildroot}%{_bindir}/kubefedctl
+install -p -m 755 $RPM_BUILD_DIR/go/src/sigs.k8s.io/kubefed/bin/kubefedctl %{buildroot}%{_bindir}/kubefedctl
 
 # EXAMPLE: Install tests
 # install -d %{buildroot}%{_libexecdir}/%{name}
@@ -123,8 +123,8 @@ install -p -m 755 $RPM_BUILD_DIR/go/bin/kubefedctl* %{buildroot}%{_bindir}/kubef
 # install -p -m 0755 _output/local/bin/${PLATFORM}/sdn-cni-plugin %{buildroot}/opt/cni/bin/openshift-sdn
 
 %files
-%doc README.md
-%license LICENSE
+%doc $RPM_BUILD_DIR/go/src/sigs.k8s.io/kubefed/README.md
+%license $RPM_BUILD_DIR/go/src/sigs.k8s.io/kubefed/LICENSE
 %{_bindir}/kubefedctl
 # EXAMPLE: Managing configuration
 # %defattr(-,root,root,0700)

--- a/kubefedctl.spec
+++ b/kubefedctl.spec
@@ -46,7 +46,7 @@
 
 %global package_name kubefed-client
 %global product_name Kubefed Client
-%global import_path github.com/openshift/kubefed # GO_PACKAGE
+%global import_path github\.com\/openshift\/kubefed # GO_PACKAGE
 
 Name:           %{package_name}
 Version:        %{version}

--- a/openshift/Makefile.ci
+++ b/openshift/Makefile.ci
@@ -28,7 +28,7 @@ LDFLAG_OPTIONS = -ldflags "-X sigs.k8s.io/kubefed/pkg/version.version=$(GIT_VERS
 	-X sigs.k8s.io/kubefed/pkg/version.gitTreeState=$(GIT_TREESTATE) \
 	-X sigs.k8s.io/kubefed/pkg/version.buildDate=$(BUILDDATE)"
 
-GO_BUILDCMD = GO111MODULE=off CGO_ENABLED=0 go build $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
+GO_BUILDCMD = CGO_ENABLED=0 go build $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 
 .PHONY: unit vet managed-e2e kubefedctl
 

--- a/openshift/Makefile.ci
+++ b/openshift/Makefile.ci
@@ -2,8 +2,6 @@
 SHELL := /bin/bash
 REGISTRY ?= quay.io/kubernetes-multicluster
 BIN_DIR := bin
-PODMAN ?= podman
-DIR := ${CURDIR}
 HOST_OS ?= $(shell uname -s | tr A-Z a-z)
 
 TARGET = kubefed
@@ -13,22 +11,15 @@ TEST_PKGS ?= $(GOTARGET)/cmd/... $(GOTARGET)/pkg/...
 TEST_CMD = go test $(TESTARGS)
 TEST = $(TEST_CMD) $(TEST_PKGS)
 
-GIT_VERSION ?= $(shell git describe --always --dirty)
-GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null)
-GIT_HASH ?= $(shell git rev-parse HEAD)
+GIT_VERSION ?= $(OS_GIT_VERSION)
+GIT_HASH ?= $(OS_GIT_COMMIT)
 BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-GIT_TREESTATE = "clean"
-DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
-ifeq ($(DIFF), 1)
-	GIT_TREESTATE = "dirty"
-endif
+GIT_TREESTATE ?= $(OS_GIT_TREE_STATE)
 
 ifneq ($(VERBOSE),)
 VERBOSE_FLAG = -v
 endif
-BUILDMNT = /go/src/$(GOTARGET)
-BUILD_IMAGE ?= golang:1.12.5
 
 KUBEFEDCTL_TARGET = bin/kubefedctl
 

--- a/openshift/Makefile.ci
+++ b/openshift/Makefile.ci
@@ -28,7 +28,7 @@ LDFLAG_OPTIONS = -ldflags "-X sigs.k8s.io/kubefed/pkg/version.version=$(GIT_VERS
 	-X sigs.k8s.io/kubefed/pkg/version.gitTreeState=$(GIT_TREESTATE) \
 	-X sigs.k8s.io/kubefed/pkg/version.buildDate=$(BUILDDATE)"
 
-GO_BUILDCMD = CGO_ENABLED=0 go build $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
+GO_BUILDCMD = GO111MODULE=off CGO_ENABLED=0 go build $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 
 .PHONY: unit vet managed-e2e kubefedctl
 


### PR DESCRIPTION
An RPM build for `kubefedctl` client is failing due to the following issue:
```
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
mkdir -p bin
CGO_ENABLED=0 go build  -ldflags "-X sigs.k8s.io/kubefed/pkg/version.version= -X sigs.k8s.io/kubefed/pkg/version.gitCommit= -X sigs.k8s.io/kubefed/pkg/version.gitTreeState="clean" -X sigs.k8s.io/kubefed/pkg/version.buildDate=2019-07-23T17:59:30Z" -o  bin/kubefedctl-linux cmd/kubefedctl/main.go
```
So removing git references from the Makefile and adding `os_git_vars` instead.