### PR TITLE
Fix downstream image builds for multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV USER_ID=1001
 
 # copy in binaries
 WORKDIR /root/
-COPY --from=builder /go/src/sigs.k8s.io/kubefed/bin/hyperfed-linux /root/hyperfed
+COPY --from=builder /go/src/sigs.k8s.io/kubefed/bin/hyperfed /root/hyperfed
 RUN ln -s hyperfed controller-manager && ln -s hyperfed kubefedctl &&  ln -s hyperfed webhook
 
 # user directive - this image does not require root


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the copied downstream image from the Docker builder so that /root/hyperfed is a valid location.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Bugzilla: 1733596
