### PR TITLE
Dockerfile fix for copying the actual file rather than just the soft link.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV USER_ID=1001
 
 # copy in binaries
 WORKDIR /root/
-COPY --from=builder /go/src/sigs.k8s.io/kubefed/bin/hyperfed /root/hyperfed
+COPY --from=builder /go/src/sigs.k8s.io/kubefed/bin/hyperfed-* /root/hyperfed
 RUN ln -s hyperfed controller-manager && ln -s hyperfed kubefedctl &&  ln -s hyperfed webhook
 
 # user directive - this image does not require root


### PR DESCRIPTION
**What this PR does / why we need it**:
The Dockerfile COPY command in docker env does a deep copy from soft-links while in podman context it only copies the soft link. This PR makes sure the actual binary is copied than just the soft-link.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 1735596
