### PR TITLE
Stop image build on make failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY cmd cmd
 COPY test test
 COPY vendor vendor
 
-RUN DOCKER_BUILD="/bin/sh -c " make hyperfed
+RUN DOCKER_BUILD="" make hyperfed
 
 # build stage 2:
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base


### PR DESCRIPTION
Right now the image build continues running even when the `make` command fails, because the wrapper `/bin/sh -c "..."` is hiding the real rc from `make`.

## How to reproduce

Given the following `Dockerfile`:

```
FROM openshift/golang-builder:1.12
RUN /bin/sh -c "invalid-cmd" ; echo $?
RUN echo "still running"
```

```
$ podman build -t foobar . --no-cache
STEP 1: FROM openshift/golang-builder:1.12
STEP 2: RUN /bin/sh -c "invalid-cmd" ; echo $?
/bin/sh: invalid-cmd: command not found
127
7dd9b26fc2381cea290dbd5da509ecd41e81d62fc10ca7eafb6683ed357970c9
STEP 3: RUN echo "still running"
still running
STEP 4: COMMIT foobar
ad7d8dc186a31dbbfa618b923a1ff7b86e8d463e3203755e7f09502447ac8538
```

It should have stopped at `STEP 2`, but didn't.