### PR TITLE
Pass the GIT env vars to make for downstream builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY cmd cmd
 COPY test test
 COPY vendor vendor
 
-RUN DOCKER_BUILD="/bin/sh -c " make hyperfed
+RUN [ -z "$SOURCE_GIT_COMMIT" ] && DOCKER_BUILD="/bin/sh -c " make hyperfed || DOCKER_BUILD="/bin/sh -c " GIT_VERSION="$BUILD_VERSION" GIT_TAG="$SOURCE_GIT_TAG" GIT_HASH="$SOURCE_GIT_COMMIT" make hyperfed
 
 # build stage 2:
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the downstream builds where certain git variables are not present in the BREW system.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
As per the Slack conversation with ART team, the reconciliation doesn't take care of passing the env. vars to any build commands. Only the env. vars get injected. These are to be used by individual team as deemed appropriate.